### PR TITLE
Fix README typos and clarify server start

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@ Quick Start:
 
   The easiest way to run it right now is by clicking the green code button and then "Open with Visual Studio" (you would need Visual Studio for this to work).
 
-  Once in Visual Studio, click the dropdown to the right of the settings cog at the top and and select Uno Server. Then click the hollow play triangle to run without debugging.
+  Once in Visual Studio, click the dropdown to the right of the settings cog at the top and select Uno Server. Then click the hollow play triangle to run without debugging.
 
-  Once the CLIUNO terminal comes up, you can type S to start the server.
+  Once the CLIUNO terminal comes up, press S to start the server.
 
   You can run multiple Uno Clients in the same fashion.
 
 Clients don't have to be on the same machine as the server. They can target any server on the same LAN!
 
-  To target a machine other than the same one the client is getting run on, you will need to change the target ip near the top of the sourcefile MainMenu.cs to the ip of the machine running the server. This would be a built-in option for each client in a more polished version.
+  To target a machine other than the one running the client, change the target IP near the top of the source file MainMenu.cs to the IP of the machine running the server. This would be a built-in option for each client in a more polished version.
 
 Notable Rules:
 


### PR DESCRIPTION
## Summary
- fix repeated word typo
- clarify how to start the server
- fix minor wording issues

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850dab43cd883339a556123949a6177