### PR TITLE
Fix wild card color validation

### DIFF
--- a/Uno.Tests/ActionUseCardTests.cs
+++ b/Uno.Tests/ActionUseCardTests.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Reflection;
+using System.Text;
+using Uno_Server.Game;
+using Uno_Server.Networking;
+
+namespace Uno.Tests;
+
+public static class TestUtils
+{
+    public static RequestHandler CreateHandler(out NetworkStream serverStream, out TcpClient serverClient)
+    {
+        TcpListener listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        TcpClient client = new TcpClient();
+        client.Connect(IPAddress.Loopback, port);
+        serverClient = listener.AcceptTcpClient();
+        listener.Stop();
+
+        RequestHandler handler = new RequestHandler(client);
+        var field = typeof(RequestHandler).GetField("clientStream", BindingFlags.NonPublic | BindingFlags.Instance);
+        field!.SetValue(handler, client.GetStream());
+        serverStream = serverClient.GetStream();
+        serverStream.ReadTimeout = 1000;
+        return handler;
+    }
+
+    public static void SetPrivateField<T>(object obj, string name, T value)
+    {
+        var field = obj.GetType().GetField(name, BindingFlags.NonPublic | BindingFlags.Instance);
+        field!.SetValue(obj, value);
+    }
+
+    public static T GetPrivateField<T>(object obj, string name)
+    {
+        var field = obj.GetType().GetField(name, BindingFlags.NonPublic | BindingFlags.Instance);
+        return (T)field!.GetValue(obj)!;
+    }
+}
+
+public class ActionUseCardTests
+{
+    [Fact]
+    public void WildWithoutColor_ReturnsErrorAndKeepsState()
+    {
+        var handler1 = TestUtils.CreateHandler(out var stream1, out var server1);
+        var handler2 = TestUtils.CreateHandler(out var stream2, out var server2);
+        var p1 = new Player(0, handler1);
+        var p2 = new Player(1, handler2);
+        var game = new Game(0, 2);
+        game.Players = new List<Player> { p1, p2 };
+
+        var draw = new Deck();
+        draw.Add(new Card(Color.Red, Value.One));
+        TestUtils.SetPrivateField(game, "drawPile", draw);
+
+        var discard = new Deck();
+        discard.Add(new Card(Color.Red, Value.Two));
+        TestUtils.SetPrivateField(game, "discardPile", discard);
+        TestUtils.SetPrivateField(game, "currentPlayerIndex", 0);
+
+        p1.Hand.Add(new Card(Color.Wild, Value.Wild));
+
+        game.ActionUseCard(0, new Card(Color.Wild, Value.Wild), null);
+
+        Assert.Single(p1.Hand.Cards);
+        Assert.Equal(Value.Wild, p1.Hand.Cards[0].Value);
+        Assert.Single(discard.Cards);
+        Assert.Equal(Value.Two, discard.Cards[0].Value);
+        Assert.Equal(0, TestUtils.GetPrivateField<int>(game, "currentPlayerIndex"));
+
+        var buffer = new byte[64];
+        int len = stream1.Read(buffer, 0, buffer.Length);
+        string msg = Encoding.ASCII.GetString(buffer, 0, len);
+        Assert.StartsWith("UNOER", msg);
+
+        server1.Close();
+        server2.Close();
+    }
+
+    [Fact]
+    public void DrawFourWithoutColor_ReturnsErrorAndKeepsState()
+    {
+        var handler1 = TestUtils.CreateHandler(out var stream1, out var server1);
+        var handler2 = TestUtils.CreateHandler(out var stream2, out var server2);
+        var p1 = new Player(0, handler1);
+        var p2 = new Player(1, handler2);
+        var game = new Game(0, 2);
+        game.Players = new List<Player> { p1, p2 };
+
+        var draw = new Deck();
+        for (int i = 0; i < 5; i++) draw.Add(new Card(Color.Red, Value.One));
+        TestUtils.SetPrivateField(game, "drawPile", draw);
+
+        var discard = new Deck();
+        discard.Add(new Card(Color.Red, Value.Two));
+        TestUtils.SetPrivateField(game, "discardPile", discard);
+        TestUtils.SetPrivateField(game, "currentPlayerIndex", 0);
+
+        p1.Hand.Add(new Card(Color.Wild, Value.DrawFour));
+
+        game.ActionUseCard(0, new Card(Color.Wild, Value.DrawFour), null);
+
+        Assert.Single(p1.Hand.Cards);
+        Assert.Equal(Value.DrawFour, p1.Hand.Cards[0].Value);
+        Assert.Empty(p2.Hand.Cards);
+        Assert.Single(discard.Cards);
+        Assert.Equal(Value.Two, discard.Cards[0].Value);
+        Assert.Equal(0, TestUtils.GetPrivateField<int>(game, "currentPlayerIndex"));
+
+        var buffer = new byte[64];
+        int len = stream1.Read(buffer, 0, buffer.Length);
+        string msg = Encoding.ASCII.GetString(buffer, 0, len);
+        Assert.StartsWith("UNOER", msg);
+
+        server1.Close();
+        server2.Close();
+    }
+}

--- a/Uno.Tests/GlobalUsings.cs
+++ b/Uno.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/Uno.Tests/Uno.Tests.csproj
+++ b/Uno.Tests/Uno.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <ProjectReference Include="..\Uno\Uno Server.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Uno.sln
+++ b/Uno.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Uno Server", "Uno\Uno Serve
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Uno Client", "Uno Client\Uno Client.csproj", "{3AF12F87-0FE5-4BC0-A6CF-1D534B794126}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Uno.Tests", "Uno.Tests\Uno.Tests.csproj", "{C070FD3F-DE5B-4468-A58F-00EB68B8EF46}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{3AF12F87-0FE5-4BC0-A6CF-1D534B794126}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3AF12F87-0FE5-4BC0-A6CF-1D534B794126}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3AF12F87-0FE5-4BC0-A6CF-1D534B794126}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C070FD3F-DE5B-4468-A58F-00EB68B8EF46}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C070FD3F-DE5B-4468-A58F-00EB68B8EF46}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C070FD3F-DE5B-4468-A58F-00EB68B8EF46}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C070FD3F-DE5B-4468-A58F-00EB68B8EF46}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Uno/Game/Game.cs
+++ b/Uno/Game/Game.cs
@@ -125,6 +125,12 @@
                 }
                 else
                 {
+                    if ((card.Value == Value.Wild || card.Value == Value.DrawFour) && newColor == null)
+                    {
+                        curPlayer.RequestHandler.Send(Protocol.ProtocolManager.Error());
+                        return;
+                    }
+
                     discardPile.Push(card);
                     curPlayer.RequestHandler.Send(Protocol.ProtocolManager.OK());
                     switch (card.Value)
@@ -154,15 +160,8 @@
                             currentPlayerIndex =NextPlayer(2);
                             break;
                         case Value.Wild:
-                            if (newColor == null)
-                            {
-                                curPlayer.RequestHandler.Send(Protocol.ProtocolManager.Error());
-                            }
-                            else
-                            {
-                                card = new(card.Color, card.Value);
-                                discardPile.Cards[0].Color = newColor.Value;
-                            }
+                            card = new(card.Color, card.Value);
+                            discardPile.Cards[0].Color = newColor!.Value;
                             currentPlayerIndex = NextPlayer();
                             break;
                         case Value.DrawFour:
@@ -175,15 +174,8 @@
                                     return;
                                 }
                             }
-                            if (newColor == null)
-                            {
-                                curPlayer.RequestHandler.Send(Protocol.ProtocolManager.Error());
-                            }
-                            else
-                            {
-                                card = new(card.Color, card.Value);
-                                discardPile.Cards[0].Color = newColor.Value;
-                            }
+                            card = new(card.Color, card.Value);
+                            discardPile.Cards[0].Color = newColor!.Value;
                             Players[NextPlayer()].Hand.InsertCard(drawPile.DrawCard());
                             Players[NextPlayer()].Hand.InsertCard(drawPile.DrawCard());
                             Players[NextPlayer()].Hand.InsertCard(drawPile.DrawCard());


### PR DESCRIPTION
## Summary
- check that a wild or draw-four card has a color before pushing it to the discard pile
- add an xUnit test project
- test that using Wild or DrawFour without a color fails and turn doesn't advance

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6850daa6bf0c8333906aa8b1db9122b6